### PR TITLE
Initialize Part with name and shortName

### DIFF
--- a/Sources/music-notation/Part.swift
+++ b/Sources/music-notation/Part.swift
@@ -21,8 +21,8 @@ public struct Part {
 
 	// MARK: - Main Properties
 
-	public let name: String = ""
-	public let shortName: String = ""
+	public let name: String
+	public let shortName: String
 
 	internal private(set) var staves: [Staff] = []
 
@@ -31,6 +31,8 @@ public struct Part {
 		shortName: String = "",
 		staves: [Staff]
 	) {
+        self.name = name
+        self.shortName = shortName
 		self.staves = staves
 	}
 }

--- a/Tests/MusicNotationTests/PartTests.swift
+++ b/Tests/MusicNotationTests/PartTests.swift
@@ -1,0 +1,35 @@
+//
+//  PartTests.swift
+//  MusicNotationCore
+//
+//  Created by Robert J. Sarvis Jr on 2/14/23.
+//
+
+@testable import MusicNotation
+import XCTest
+
+// swiftlint:disable force_try
+// swiftlint:disable implicitly_unwrapped_optional
+final class PartTests: XCTestCase {
+    
+    let testPartName = "testPartName"
+    let testPartShortName = "testShortName"
+    
+    var part: Part!
+    
+    override func setUp() {
+        super.setUp()
+        let staff = Staff(clef: .treble, instrument: Instrument())
+        part = Part(name: testPartName, shortName: testPartShortName, staves: [staff])
+    }
+    
+    func testDescription() {
+        XCTAssertEqual(part!.debugDescription, "staves(staff(treble Instrument(name: \"\", lineCount: 0, chromaticTransposition: 0, octaveTransposition: 0) ))")
+    }
+    
+    func testPartNames() {
+        XCTAssertEqual(part!.name, testPartName)
+        XCTAssertEqual(part!.shortName, testPartShortName)
+    }
+
+}


### PR DESCRIPTION
Noticed a minor issue with the Part struct not making use of the name and shortName values it is initialized with. Please let me know if I need to add or change anything. Thank you!